### PR TITLE
Add Prisma ORM and some server actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Create a `.env.local` file in the root directory with the following values (get 
 
 ```
 NEXT_PUBLIC_MAPBOX_TOKEN=pk.eyJ1I...
+DATABASE_URL="mongodb://..."
+```
+
+Run the setup command to install dependencies and generate the Prisma client:
+
+```
+npm run setup
 ```
 
 Install dependencies using:

--- a/lib/actions/shelter.ts
+++ b/lib/actions/shelter.ts
@@ -1,0 +1,16 @@
+'use server';
+import { prisma } from '@/lib/prisma';
+import type { Shelter } from '@prisma/client';
+import type { ActionResult } from '@/types/models';
+
+/**
+ * Action that fetches all shelters from the database
+ */
+export async function getShelters(): Promise<ActionResult<Shelter[]>> {
+  try {
+    const shelters = await prisma.shelter.findMany();
+    return { success: true, data: shelters };
+  } catch {
+    throw new Error('[ShelterList] Failed to fetch shelters from database');
+  }
+}

--- a/lib/actions/volunteer.ts
+++ b/lib/actions/volunteer.ts
@@ -1,0 +1,60 @@
+'use server';
+import { prisma } from '@/lib/prisma';
+import { validateTimeSlot } from '@/lib/utils/dates';
+import type { SignupDetails } from '@/types/shelter';
+import type {
+  VolunteerSignupCreationAttributes,
+  ActionResult,
+} from '@/types/models';
+
+/**
+ * Action that creates a new volunteer signup
+ */
+export async function signupVolunteer({
+  volunteerId,
+  shelterId,
+  timeSlot,
+}: VolunteerSignupCreationAttributes): Promise<ActionResult<SignupDetails>> {
+  if (!volunteerId || !shelterId) {
+    throw new Error(
+      '[VolunteerSignup] Volunteer ID and Shelter ID are required',
+    );
+  }
+
+  if (!validateTimeSlot(timeSlot)) {
+    throw new Error('[VolunteerSignup] Invalid time slot');
+  }
+
+  try {
+    const signup = await prisma.volunteerSignup.create({
+      data: {
+        volunteerId,
+        shelterId,
+        timeSlot: {
+          start: new Date(timeSlot.start),
+          end: new Date(timeSlot.end),
+        },
+        status: 'pending',
+      },
+      include: {
+        volunteer: {
+          select: {
+            name: true,
+            email: true,
+            phoneNumber: true,
+          },
+        },
+        shelter: {
+          select: {
+            name: true,
+            address: true,
+          },
+        },
+      },
+    });
+
+    return { success: true, data: { ...signup } };
+  } catch {
+    throw new Error('[VolunteerSignup] Database operation failed');
+  }
+}

--- a/lib/hooks/useShelters.ts
+++ b/lib/hooks/useShelters.ts
@@ -1,0 +1,17 @@
+'use client';
+import { use } from 'react';
+import { getShelters } from '@/lib/actions/shelter';
+import type { Shelter } from '@prisma/client';
+
+/** Hook for fetching shelters */
+export function useShelters(): Shelter[] {
+  const result = use(getShelters());
+
+  if (!result.success) {
+    // TODO: Add better client-visible error handling.
+    console.error('[ShelterList] Failed to fetch shelters');
+    return [];
+  }
+
+  return result.data;
+}

--- a/lib/hooks/useVolunteerSignup.ts
+++ b/lib/hooks/useVolunteerSignup.ts
@@ -1,0 +1,22 @@
+'use client';
+import { signupVolunteer } from '@/lib/actions/volunteer';
+import type { VolunteerSignupCreationAttributes } from '@/types/models';
+
+import { SignupDetails } from '@/types/shelter';
+
+/**
+ * Hook that returns a callback for signing up a volunteer for a timeslot.
+ * Returns null if the signup fails and the details if successful.
+ */
+export function useVolunteerSignup() {
+  return async (
+    params: VolunteerSignupCreationAttributes,
+  ): Promise<SignupDetails | null> => {
+    const result = await signupVolunteer(params);
+    if (!result.success) {
+      console.error('[VolunteerSignup] Failed to sign up for shelter');
+      return null;
+    }
+    return result.data;
+  };
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,12 @@
+import { isValid, type Interval } from 'date-fns';
+
+/**
+ * Function that checks that the timeslot's start and end are each valid with start < end
+ */
+export function validateTimeSlot(timeSlot: Interval): boolean {
+  return (
+    isValid(timeSlot.start) &&
+    isValid(timeSlot.end) &&
+    timeSlot.start < timeSlot.end
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mui/icons-material": "^6.4.3",
         "@mui/material": "^6.4.3",
+        "@prisma/client": "^6.3.1",
         "@types/mapbox-gl": "^3.4.1",
         "classnames": "^2.5.1",
+        "date-fns": "^4.1.0",
         "mapbox-gl": "^3.9.4",
         "motion": "^12.4.1",
         "next": "15.1.6",
@@ -45,6 +47,7 @@
         "postcss": "^8",
         "prettier": "^3.4.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
+        "prisma": "^6.3.1",
         "storybook": "^8.5.3",
         "tailwindcss": "^3.4.1",
         "typescript": "^5",
@@ -3782,6 +3785,72 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.3.1.tgz",
+      "integrity": "sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.3.1.tgz",
+      "integrity": "sha512-RrEBkd+HLZx+ydfmYT0jUj7wjLiS95wfTOSQ+8FQbvb6vHh5AeKfEPt/XUQ5+Buljj8hltEfOslEW57/wQIVeA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.3.1.tgz",
+      "integrity": "sha512-sXdqEVLyGAJ5/iUoG/Ea5AdHMN71m6PzMBWRQnLmhhOejzqAaEr8rUd623ql6OJpED4s/U4vIn4dg1qkF7vGag==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/fetch-engine": "6.3.1",
+        "@prisma/get-platform": "6.3.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0.tgz",
+      "integrity": "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.3.1.tgz",
+      "integrity": "sha512-HOf/0umOgt+/S2xtZze+FHKoxpVg4YpVxROr6g2YG09VsI3Ipyb+rGvD6QGbCqkq5NTWAAZoOGNL+oy7t+IhaQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/get-platform": "6.3.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.3.1.tgz",
+      "integrity": "sha512-AYLq6Hk9xG73JdLWJ3Ip9Wg/vlP7xPvftGBalsPzKDOHr/ImhwJ09eS8xC2vNT12DlzGxhfk8BkL0ve2OriNhQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "6.3.1"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -7190,6 +7259,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -11724,6 +11802,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prisma": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.3.1.tgz",
+      "integrity": "sha512-JKCZWvBC3enxk51tY4TWzS4b5iRt4sSU1uHn2I183giZTvonXaQonzVtjLzpOHE7qu9MxY510kAtFGJwryKe3Q==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "6.3.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -13940,7 +14045,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "setup": "npm install && prisma generate"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -21,8 +22,10 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mui/icons-material": "^6.4.3",
     "@mui/material": "^6.4.3",
+    "@prisma/client": "^6.3.1",
     "@types/mapbox-gl": "^3.4.1",
     "classnames": "^2.5.1",
+    "date-fns": "^4.1.0",
     "mapbox-gl": "^3.9.4",
     "motion": "^12.4.1",
     "next": "15.1.6",
@@ -51,6 +54,7 @@
     "postcss": "^8",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.11",
+    "prisma": "^6.3.1",
     "storybook": "^8.5.3",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,102 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  VOLUNTEER
+  COORDINATOR
+}
+
+enum Language {
+  ENGLISH
+  SPANISH
+  FRENCH
+  MANDARIN
+  CANTONESE
+  VIETNAMESE
+  TAGALOG
+  KOREAN
+  JAPANESE
+  ARABIC
+  OTHER
+}
+
+type Address {
+  street    String
+  city      String
+  state     String
+  zipCode   String
+  country   String
+}
+
+type Coordinate {
+  latitude  Float
+  longitude Float
+}
+
+type TimeSlot {
+  start DateTime
+  end   DateTime
+}
+
+model Volunteer {
+  id              String            @id @default(auto()) @map("_id") @db.ObjectId
+  role            Role             @default(VOLUNTEER)
+  name            String
+  email           String           @unique
+  phoneNumber     String
+  profilePicture  String?
+  languages       Language[]
+  canLiftHeavy    Boolean          @default(false)
+  signups         VolunteerSignup[]
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+}
+
+model Shelter {
+  id                  String            @id @default(auto()) @map("_id") @db.ObjectId
+  name                String
+  location            Coordinate?
+  address             Address
+  picture             String?
+  volunteerCapacity   Int?
+  evacueeCapacity     Int?
+  accommodations      String[]
+  wheelchairAccessible Boolean          @default(false)
+  housesLargeAnimals  Boolean          @default(false)
+  housesSmallAnimals  Boolean          @default(false)
+  hasCounselingUnit   Boolean          @default(false)
+  foodProvided        Boolean          @default(false)
+  waterProvided       Boolean          @default(false)
+  volunteerPreferences Json?
+  requiredLanguages   Language[]
+  signups             VolunteerSignup[]
+  createdAt           DateTime         @default(now())
+  updatedAt           DateTime         @updatedAt
+}
+
+model VolunteerSignup {
+  id          String    @id @default(auto()) @map("_id") @db.ObjectId
+  shelterId   String    @db.ObjectId
+  volunteerId String    @db.ObjectId
+  timeSlot    TimeSlot
+  status      String    @default("pending") // pending, confirmed, cancelled
+  shelter     Shelter   @relation(fields: [shelterId], references: [id])
+  volunteer   Volunteer @relation(fields: [volunteerId], references: [id])
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([shelterId])
+  @@index([volunteerId])
+}

--- a/types/models.ts
+++ b/types/models.ts
@@ -1,0 +1,35 @@
+import type { Interval } from 'date-fns';
+import type { Volunteer, Shelter, VolunteerSignup } from '@prisma/client';
+
+/** Result of an action that returns a value */
+export type ActionResult<T> = { success: true; data: T } | { success: false };
+
+/** Attributes for creating a new volunteer signup database entry */
+export interface VolunteerSignupCreationAttributes
+  extends Pick<VolunteerSignup, 'volunteerId' | 'shelterId'> {
+  timeSlot: Interval;
+}
+
+/** Attributes for creating a new volunteer database entry */
+export interface VolunteerCreationAttributes
+  extends Pick<
+    Volunteer,
+    'name' | 'email' | 'phoneNumber' | 'languages' | 'canLiftHeavy'
+  > {}
+
+/** Attributes for creating a new shelter database entry */
+export interface ShelterCreationAttributes
+  extends Pick<
+    Shelter,
+    | 'name'
+    | 'address'
+    | 'location'
+    | 'volunteerCapacity'
+    | 'evacueeCapacity'
+    | 'wheelchairAccessible'
+    | 'housesLargeAnimals'
+    | 'housesSmallAnimals'
+    | 'foodProvided'
+    | 'waterProvided'
+    | 'requiredLanguages'
+  > {}

--- a/types/shelter.ts
+++ b/types/shelter.ts
@@ -1,0 +1,14 @@
+import type { Shelter, Volunteer, VolunteerSignup } from '@prisma/client';
+import type { Interval } from 'date-fns';
+
+export interface VolunteerDetails
+  extends Pick<Volunteer, 'name' | 'email' | 'phoneNumber'> {}
+
+export interface ShelterDetails extends Pick<Shelter, 'name' | 'address'> {}
+
+/** Details returned when a volunteer signs up for a timeslot */
+export interface SignupDetails extends Pick<VolunteerSignup, 'status'> {
+  volunteer: VolunteerDetails;
+  shelter: ShelterDetails;
+  timeSlot: Interval;
+}


### PR DESCRIPTION
# Context
This PR adds Prisma, the server database models, and some server actions/hooks used for creating/getting data

# Changes
- added Prisma ORM
- added shelter and volunteer data models
- created server actions and hooks for shelter/volunteer
- Updated `README.md` with `npm run setup` command

# Testing
No testing yet since we need to get an actual MongoDB database URL. When that gets added, we can add some jest unit testing for the server actions (or maybe NextJS has a unit testing framework)