### PR TITLE
Add sorting shelters by distance from user

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,42 @@
-"use client"
-import { useState } from "react";
+'use client';
+import { useState } from 'react';
 
 import AdminList from '@/components/AdminList';
-import { Box, Typography, Button, Dialog, DialogTitle, DialogContent, TextField, DialogActions, IconButton, Chip } from '@mui/material';
-import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  DialogActions,
+  IconButton,
+  Chip,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 import { Shelter } from '@prisma/client';
-import { useShelters, useAddShelter, useDeleteShelter, useUpdateShelter } from "@/lib/hooks/useShelters";
+import {
+  useShelters,
+  useAddShelter,
+  useDeleteShelter,
+  useUpdateShelter,
+} from '@/lib/hooks/useShelters';
 
 import type { ActionResult } from '@/types/models';
 
 interface NewShelterForm {
   name: string;
-  location: { latitude: string; longitude: string };
-  address: { street: string; city: string; state: string; zipCode: string; country: string };
+  location: { type: string; coordinates: number[] };
+  address: {
+    street: string;
+    city: string;
+    state: string;
+    zipCode: string;
+    country: string;
+  };
   picture: string;
   volunteerCapacity: string;
   evacueeCapacity: string;
@@ -30,19 +52,20 @@ interface NewShelterForm {
 
 export default function Page() {
   const { shelters, loading, error, refetch } = useShelters();
-  const { handleAddShelter: addShelterAction, loading: addLoading } = useAddShelter();
+  const { handleAddShelter: addShelterAction, loading: addLoading } =
+    useAddShelter();
   const { handleDelete } = useDeleteShelter();
   const { handleUpdateShelter, loading: updateLoading } = useUpdateShelter();
 
   const [open, setOpen] = useState(false);
   const [editingShelterId, setEditingShelterId] = useState<string | null>(null);
   const [newShelter, setNewShelter] = useState<NewShelterForm>({
-    name: "",
-    location: { latitude: "", longitude: "" },
-    address: { street: "", city: "", state: "", zipCode: "", country: "" },
-    picture: "",
-    volunteerCapacity: "",
-    evacueeCapacity: "",
+    name: '',
+    location: { type: 'Point', coordinates: [] },
+    address: { street: '', city: '', state: '', zipCode: '', country: '' },
+    picture: '',
+    volunteerCapacity: '',
+    evacueeCapacity: '',
     accommodations: [],
     suppliesNeeded: [],
     wheelchairAccessible: false,
@@ -51,7 +74,6 @@ export default function Page() {
     hasCounselingUnit: false,
     foodProvided: false,
     waterProvided: false,
-
   });
 
   if (loading) {
@@ -68,8 +90,10 @@ export default function Page() {
       setNewShelter({
         name: shelter.name,
         location: {
-          latitude: shelter.location ? String(shelter.location.latitude) : "",
-          longitude: shelter.location ? String(shelter.location.longitude) : "",
+          type: 'Point',
+          coordinates: shelter.location
+            ? [shelter.location.coordinates[0], shelter.location.coordinates[1]]
+            : [],
         },
         address: {
           street: shelter.address.street,
@@ -78,16 +102,20 @@ export default function Page() {
           zipCode: shelter.address.zipCode,
           country: shelter.address.country,
         },
-        picture: shelter.picture ?? "",
-        volunteerCapacity: shelter.volunteerCapacity ? String(shelter.volunteerCapacity) : "",
-        evacueeCapacity: shelter.evacueeCapacity ? String(shelter.evacueeCapacity) : "",
+        picture: shelter.picture ?? '',
+        volunteerCapacity: shelter.volunteerCapacity
+          ? String(shelter.volunteerCapacity)
+          : '',
+        evacueeCapacity: shelter.evacueeCapacity
+          ? String(shelter.evacueeCapacity)
+          : '',
         accommodations: shelter.accommodations ?? [],
         suppliesNeeded: shelter.suppliesNeeded
-          ? shelter.suppliesNeeded.map(supply => ({
-            item: supply.item,
-            received: String(supply.received),
-            needed: String(supply.needed),
-          }))
+          ? shelter.suppliesNeeded.map((supply) => ({
+              item: supply.item,
+              received: String(supply.received),
+              needed: String(supply.needed),
+            }))
           : [],
         wheelchairAccessible: shelter.wheelchairAccessible,
         housesLargeAnimals: shelter.housesLargeAnimals,
@@ -99,12 +127,12 @@ export default function Page() {
     } else {
       setEditingShelterId(null);
       setNewShelter({
-        name: "",
-        location: { latitude: "", longitude: "" },
-        address: { street: "", city: "", state: "", zipCode: "", country: "" },
-        picture: "",
-        volunteerCapacity: "",
-        evacueeCapacity: "",
+        name: '',
+        location: { type: 'Point', coordinates: [] },
+        address: { street: '', city: '', state: '', zipCode: '', country: '' },
+        picture: '',
+        volunteerCapacity: '',
+        evacueeCapacity: '',
         accommodations: [],
         suppliesNeeded: [],
         wheelchairAccessible: false,
@@ -122,12 +150,12 @@ export default function Page() {
     setOpen(false);
     setEditingShelterId(null);
     setNewShelter({
-      name: "",
-      location: { latitude: "", longitude: "" },
-      address: { street: "", city: "", state: "", zipCode: "", country: "" },
-      picture: "",
-      volunteerCapacity: "",
-      evacueeCapacity: "",
+      name: '',
+      location: { type: 'Point', coordinates: [] },
+      address: { street: '', city: '', state: '', zipCode: '', country: '' },
+      picture: '',
+      volunteerCapacity: '',
+      evacueeCapacity: '',
       accommodations: [],
       suppliesNeeded: [],
       wheelchairAccessible: false,
@@ -144,12 +172,16 @@ export default function Page() {
 
     const formattedShelter = {
       name: newShelter.name,
-      location: (newShelter.location.latitude && newShelter.location.longitude)
-        ? {
-          latitude: parseFloat(newShelter.location.latitude),
-          longitude: parseFloat(newShelter.location.longitude),
-        }
-        : null,
+      location:
+        newShelter.location.coordinates.length === 2
+          ? {
+              type: 'Point',
+              coordinates: [
+                parseFloat(String(newShelter.location.coordinates[0])),
+                parseFloat(String(newShelter.location.coordinates[1])),
+              ],
+            }
+          : null,
       address: {
         street: newShelter.address.street,
         city: newShelter.address.city,
@@ -158,10 +190,14 @@ export default function Page() {
         country: newShelter.address.country,
       },
       picture: newShelter.picture || null,
-      volunteerCapacity: newShelter.volunteerCapacity ? parseInt(newShelter.volunteerCapacity) : null,
-      evacueeCapacity: newShelter.evacueeCapacity ? parseInt(newShelter.evacueeCapacity) : null,
+      volunteerCapacity: newShelter.volunteerCapacity
+        ? parseInt(newShelter.volunteerCapacity)
+        : null,
+      evacueeCapacity: newShelter.evacueeCapacity
+        ? parseInt(newShelter.evacueeCapacity)
+        : null,
       accommodations: newShelter.accommodations,
-      suppliesNeeded: newShelter.suppliesNeeded.map(supply => ({
+      suppliesNeeded: newShelter.suppliesNeeded.map((supply) => ({
         item: supply.item,
         received: Number(supply.received),
         needed: Number(supply.needed),
@@ -171,16 +207,21 @@ export default function Page() {
       housesSmallAnimals: newShelter.housesLargeAnimals,
       hasCounselingUnit: newShelter.hasCounselingUnit,
       foodProvided: newShelter.foodProvided,
-      waterProvided: newShelter.waterProvided
+      waterProvided: newShelter.waterProvided,
     };
 
     if (editingShelterId) {
-      const result = await handleUpdateShelter(editingShelterId, formattedShelter) as ActionResult<Shelter>;
+      const result = (await handleUpdateShelter(
+        editingShelterId,
+        formattedShelter,
+      )) as ActionResult<Shelter>;
       if (result.success && result.data) {
         await refetch();
       }
     } else {
-      const result = await addShelterAction(formattedShelter) as ActionResult<Shelter>;
+      const result = (await addShelterAction(
+        formattedShelter,
+      )) as ActionResult<Shelter>;
       if (result.success && result.data) {
         await refetch();
       }
@@ -196,7 +237,7 @@ export default function Page() {
   const addAccommodation = () => {
     setNewShelter({
       ...newShelter,
-      accommodations: [...newShelter.accommodations, ""],
+      accommodations: [...newShelter.accommodations, ''],
     });
   };
 
@@ -215,11 +256,18 @@ export default function Page() {
   const addSupply = () => {
     setNewShelter({
       ...newShelter,
-      suppliesNeeded: [...newShelter.suppliesNeeded, { item: "", received: "", needed: "" }],
+      suppliesNeeded: [
+        ...newShelter.suppliesNeeded,
+        { item: '', received: '', needed: '' },
+      ],
     });
   };
 
-  const updateSupply = (index: number, field: "item" | "received" | "needed", value: string) => {
+  const updateSupply = (
+    index: number,
+    field: 'item' | 'received' | 'needed',
+    value: string,
+  ) => {
     const updated = [...newShelter.suppliesNeeded];
     updated[index] = { ...updated[index], [field]: value };
     setNewShelter({ ...newShelter, suppliesNeeded: updated });
@@ -231,20 +279,36 @@ export default function Page() {
     setNewShelter({ ...newShelter, suppliesNeeded: updated });
   };
 
-
   return (
     <div>
       <title>ShelterConnect | Admin</title>
-      <Box sx={{ maxWidth: 600, margin: "auto", pt: 4 }}>
-        <Typography variant="h4" sx={{ fontWeight: "bold", ml: 1.5 }}>
+      <Box sx={{ maxWidth: 600, margin: 'auto', pt: 4 }}>
+        <Typography variant="h4" sx={{ fontWeight: 'bold', ml: 1.5 }}>
           My Shelters
         </Typography>
-        <Box sx={{ display: "flex", justifyContent: "flex-start", mt: 1, mb: 2, ml: 2 }}>
-          <Button variant="contained" color="primary" sx={{ textTransform: "none", borderRadius: "6px" }} onClick={() => setOpen(true)} >
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            mt: 1,
+            mb: 2,
+            ml: 2,
+          }}
+        >
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ textTransform: 'none', borderRadius: '6px' }}
+            onClick={() => setOpen(true)}
+          >
             + New
           </Button>
         </Box>
-        <AdminList shelters={shelters} onDelete={handleDeleteShelter} onEdit={handleOpen} />
+        <AdminList
+          shelters={shelters}
+          onDelete={handleDeleteShelter}
+          onEdit={handleOpen}
+        />
 
         <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
           <DialogTitle>Add New Shelter</DialogTitle>
@@ -253,7 +317,9 @@ export default function Page() {
               label="Shelter Name"
               fullWidth
               value={newShelter.name}
-              onChange={(e) => setNewShelter({ ...newShelter, name: e.target.value })}
+              onChange={(e) =>
+                setNewShelter({ ...newShelter, name: e.target.value })
+              }
               sx={{ mb: 2, mt: 1 }}
             />
 
@@ -262,7 +328,10 @@ export default function Page() {
               fullWidth
               value={newShelter.address.street}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, address: { ...newShelter.address, street: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  address: { ...newShelter.address, street: e.target.value },
+                })
               }
               sx={{ mb: 2 }}
             />
@@ -271,7 +340,10 @@ export default function Page() {
               fullWidth
               value={newShelter.address.city}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, address: { ...newShelter.address, city: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  address: { ...newShelter.address, city: e.target.value },
+                })
               }
               sx={{ mb: 2 }}
             />
@@ -280,7 +352,10 @@ export default function Page() {
               fullWidth
               value={newShelter.address.state}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, address: { ...newShelter.address, state: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  address: { ...newShelter.address, state: e.target.value },
+                })
               }
               sx={{ mb: 2 }}
             />
@@ -289,7 +364,10 @@ export default function Page() {
               fullWidth
               value={newShelter.address.zipCode}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, address: { ...newShelter.address, zipCode: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  address: { ...newShelter.address, zipCode: e.target.value },
+                })
               }
               sx={{ mb: 2 }}
             />
@@ -298,7 +376,10 @@ export default function Page() {
               fullWidth
               value={newShelter.address.country}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, address: { ...newShelter.address, country: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  address: { ...newShelter.address, country: e.target.value },
+                })
               }
               sx={{ mb: 2 }}
             />
@@ -306,102 +387,160 @@ export default function Page() {
               label="Picture URL (optional)"
               fullWidth
               value={newShelter.picture}
-              onChange={(e) => setNewShelter({ ...newShelter, picture: e.target.value })}
+              onChange={(e) =>
+                setNewShelter({ ...newShelter, picture: e.target.value })
+              }
               sx={{ mb: 2 }}
             />
             <TextField
               label="Volunteer Capacity (optional)"
               fullWidth
               value={newShelter.volunteerCapacity}
-              onChange={(e) => setNewShelter({ ...newShelter, volunteerCapacity: e.target.value })}
+              onChange={(e) =>
+                setNewShelter({
+                  ...newShelter,
+                  volunteerCapacity: e.target.value,
+                })
+              }
               sx={{ mb: 2 }}
             />
             <TextField
               label="Evacuee Capacity (optional)"
               fullWidth
               value={newShelter.evacueeCapacity}
-              onChange={(e) => setNewShelter({ ...newShelter, evacueeCapacity: e.target.value })}
-              sx={{ mb: 2 }}
-            />
-            <TextField
-              label="Latitude (optional)"
-              fullWidth
-              value={newShelter.location.latitude}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, location: { ...newShelter.location, latitude: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  evacueeCapacity: e.target.value,
+                })
               }
               sx={{ mb: 2 }}
             />
             <TextField
               label="Longitude (optional)"
               fullWidth
-              value={newShelter.location.longitude}
+              value={newShelter.location.coordinates[0] || ''}
               onChange={(e) =>
-                setNewShelter({ ...newShelter, location: { ...newShelter.location, longitude: e.target.value } })
+                setNewShelter({
+                  ...newShelter,
+                  location: {
+                    ...newShelter.location,
+                    coordinates: [
+                      parseFloat(e.target.value) || 0,
+                      newShelter.location.coordinates[1] || 0,
+                    ],
+                  },
+                })
+              }
+              sx={{ mb: 2 }}
+            />
+            <TextField
+              label="Latitude (optional)"
+              fullWidth
+              value={newShelter.location.coordinates[1] || ''}
+              onChange={(e) =>
+                setNewShelter({
+                  ...newShelter,
+                  location: {
+                    ...newShelter.location,
+                    coordinates: [
+                      newShelter.location.coordinates[0] || 0,
+                      parseFloat(e.target.value) || 0,
+                    ],
+                  },
+                })
               }
               sx={{ mb: 2 }}
             />
 
-            <Typography variant="subtitle1" sx={{ mt: 2 }}>Shelter Options:</Typography>
+            <Typography variant="subtitle1" sx={{ mt: 2 }}>
+              Shelter Options:
+            </Typography>
             <Chip
               label="Wheelchair Accessible"
               onClick={() =>
-                setNewShelter({ ...newShelter, wheelchairAccessible: !newShelter.wheelchairAccessible })
+                setNewShelter({
+                  ...newShelter,
+                  wheelchairAccessible: !newShelter.wheelchairAccessible,
+                })
               }
-              color={newShelter.wheelchairAccessible ? "primary" : "default"}
+              color={newShelter.wheelchairAccessible ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
             <Chip
               label="Houses Large Animals"
               onClick={() =>
-                setNewShelter({ ...newShelter, housesLargeAnimals: !newShelter.housesLargeAnimals })
+                setNewShelter({
+                  ...newShelter,
+                  housesLargeAnimals: !newShelter.housesLargeAnimals,
+                })
               }
-              color={newShelter.housesLargeAnimals ? "primary" : "default"}
+              color={newShelter.housesLargeAnimals ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
             <Chip
               label="Houses Small Animals"
               onClick={() =>
-                setNewShelter({ ...newShelter, housesSmallAnimals: !newShelter.housesSmallAnimals })
+                setNewShelter({
+                  ...newShelter,
+                  housesSmallAnimals: !newShelter.housesSmallAnimals,
+                })
               }
-              color={newShelter.housesSmallAnimals ? "primary" : "default"}
+              color={newShelter.housesSmallAnimals ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
             <Chip
               label="Counseling Unit"
               onClick={() =>
-                setNewShelter({ ...newShelter, hasCounselingUnit: !newShelter.hasCounselingUnit })
+                setNewShelter({
+                  ...newShelter,
+                  hasCounselingUnit: !newShelter.hasCounselingUnit,
+                })
               }
-              color={newShelter.hasCounselingUnit ? "primary" : "default"}
+              color={newShelter.hasCounselingUnit ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
             <Chip
               label="Food Provided"
               onClick={() =>
-                setNewShelter({ ...newShelter, foodProvided: !newShelter.foodProvided })
+                setNewShelter({
+                  ...newShelter,
+                  foodProvided: !newShelter.foodProvided,
+                })
               }
-              color={newShelter.foodProvided ? "primary" : "default"}
+              color={newShelter.foodProvided ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
             <Chip
               label="Water Provided"
               onClick={() =>
-                setNewShelter({ ...newShelter, waterProvided: !newShelter.waterProvided })
+                setNewShelter({
+                  ...newShelter,
+                  waterProvided: !newShelter.waterProvided,
+                })
               }
-              color={newShelter.waterProvided ? "primary" : "default"}
+              color={newShelter.waterProvided ? 'primary' : 'default'}
               sx={{ mr: 1, mb: 1 }}
             />
 
-            <Typography variant="subtitle1">Accommodations (optional):</Typography>
+            <Typography variant="subtitle1">
+              Accommodations (optional):
+            </Typography>
             {newShelter.accommodations.map((acc, index) => (
-              <Box key={index} sx={{ display: "flex", alignItems: "center", mb: 2, gap: 1 }}>
+              <Box
+                key={index}
+                sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1 }}
+              >
                 <TextField
                   label={`Accommodation ${index + 1}`}
                   fullWidth
                   value={acc}
                   onChange={(e) => updateAccommodation(index, e.target.value)}
                 />
-                <IconButton onClick={() => deleteAccommodation(index)} color="error">
+                <IconButton
+                  onClick={() => deleteAccommodation(index)}
+                  color="error"
+                >
                   <DeleteIcon />
                 </IconButton>
               </Box>
@@ -410,26 +549,35 @@ export default function Page() {
               <AddIcon />
             </IconButton>
 
-            <Typography variant="subtitle1">Supplies Needed (optional):</Typography>
+            <Typography variant="subtitle1">
+              Supplies Needed (optional):
+            </Typography>
             {newShelter.suppliesNeeded.map((supply, index) => (
-              <Box key={index} sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+              <Box
+                key={index}
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}
+              >
                 <TextField
                   label={`Item ${index + 1}`}
                   fullWidth
                   value={supply.item}
-                  onChange={(e) => updateSupply(index, "item", e.target.value)}
+                  onChange={(e) => updateSupply(index, 'item', e.target.value)}
                 />
                 <TextField
                   label="Received"
                   fullWidth
                   value={supply.received}
-                  onChange={(e) => updateSupply(index, "received", e.target.value)}
+                  onChange={(e) =>
+                    updateSupply(index, 'received', e.target.value)
+                  }
                 />
                 <TextField
                   label="Needed"
                   fullWidth
                   value={supply.needed}
-                  onChange={(e) => updateSupply(index, "needed", e.target.value)}
+                  onChange={(e) =>
+                    updateSupply(index, 'needed', e.target.value)
+                  }
                 />
                 <IconButton onClick={() => deleteSupply(index)} color="error">
                   <DeleteIcon />
@@ -441,9 +589,16 @@ export default function Page() {
             </IconButton>
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose} color="error">Cancel</Button>
-            <Button onClick={handleAddOrUpdateShelter} variant="contained" color="primary" disabled={addLoading || updateLoading}>
-              {editingShelterId ? "Update" : "Add"}
+            <Button onClick={handleClose} color="error">
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAddOrUpdateShelter}
+              variant="contained"
+              color="primary"
+              disabled={addLoading || updateLoading}
+            >
+              {editingShelterId ? 'Update' : 'Add'}
             </Button>
           </DialogActions>
         </Dialog>

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -34,8 +34,8 @@ async function getLocationFromIP(): Promise<LatLng | null> {
 
     if (data.latitude && data.longitude) {
       return {
-        latitude: data.latitude,
         longitude: data.longitude,
+        latitude: data.latitude,
       };
     }
     return null;

--- a/components/ShelterDetails.tsx
+++ b/components/ShelterDetails.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Shelter } from '@prisma/client';
-import { Supply, VolunteerPreferences } from '@/types/shelter';
 import { useSession } from '@clerk/nextjs';
 
 enum Role {
@@ -21,11 +20,8 @@ export default function ShelterDetails({ shelter }: { shelter: Shelter }) {
   const role: Role =
     (session?.user?.unsafeMetadata?.role as Role) || Role.EVACUEE;
 
-  // Cast suppliesNeeded to Supply[]
-  const suppliesNeeded: Supply[] = (shelter.suppliesNeeded as any) || [];
-  // Cast volunteerPreferences to VolunteerPreferences
-  const volunteerPreferences: VolunteerPreferences =
-    (shelter.volunteerPreferences as any) || null;
+  const suppliesNeeded = shelter.suppliesNeeded;
+  const volunteerPreferences = shelter.volunteerPreferences;
 
   return (
     <div className="flex min-h-screen flex-col items-center bg-gray-50 p-4">
@@ -44,8 +40,9 @@ export default function ShelterDetails({ shelter }: { shelter: Shelter }) {
 
               {shelter.location && (
                 <p>
-                  <strong>Coordinates:</strong> {shelter.location.latitude},{' '}
-                  {shelter.location.longitude}
+                  <strong>Coordinates:</strong>{' '}
+                  {shelter.location.coordinates[1]},{' '}
+                  {shelter.location.coordinates[0]}
                 </p>
               )}
 

--- a/components/ShelterList.tsx
+++ b/components/ShelterList.tsx
@@ -10,13 +10,9 @@ import { useCallback } from 'react';
 import CheckboxGroup from '@/src/components/CheckboxGroup';
 import { useShelterStore } from '@/lib/store/shelterStore';
 import type { GetSheltersParams } from '@/lib/actions/shelter.schema';
-import useOnMount from '@/src/hooks/useOnMount';
 
 export default function ShelterList() {
   const { shelters, loading, setFilters, fetchShelters } = useShelterStore();
-  useOnMount(() => {
-    fetchShelters();
-  });
 
   const handleSearch = useCallback(() => {
     fetchShelters();

--- a/components/ShelterList.tsx
+++ b/components/ShelterList.tsx
@@ -4,29 +4,82 @@ import {
   faHouseChimney,
   faMagnifyingGlass,
   faSpinner,
+  faChevronLeft,
+  faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 import ShelterQuickInfo from './ShelterQuickInfo';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import CheckboxGroup from '@/src/components/CheckboxGroup';
 import { useShelterStore } from '@/lib/store/shelterStore';
 import type { GetSheltersParams } from '@/lib/actions/shelter.schema';
 
+const ITEMS_PER_PAGE = 9;
+
 export default function ShelterList() {
-  const { shelters, loading, setFilters, fetchShelters } = useShelterStore();
+  const {
+    shelters,
+    loading,
+    setFilters,
+    fetchShelters,
+    totalShelters,
+    currentPage,
+  } = useShelterStore();
+
+  const totalPages = useMemo(() => {
+    return Math.ceil(totalShelters / ITEMS_PER_PAGE);
+  }, [totalShelters]);
 
   const handleSearch = useCallback(() => {
+    setFilters((prev: GetSheltersParams) => ({
+      ...prev,
+      pagination: {
+        page: 1,
+        limit: ITEMS_PER_PAGE,
+      },
+    }));
     fetchShelters();
-  }, [fetchShelters]);
+  }, [setFilters, fetchShelters]);
 
   const handleFilterChange = useCallback(
     (value: string, checked: boolean) => {
       setFilters((prev: GetSheltersParams) => ({
         ...prev,
         [value]: checked || undefined,
+        pagination: {
+          page: 1,
+          limit: ITEMS_PER_PAGE,
+        },
       }));
+      fetchShelters();
     },
-    [setFilters],
+    [setFilters, fetchShelters],
   );
+
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      setFilters((prev: GetSheltersParams) => ({
+        ...prev,
+        pagination: {
+          page: newPage,
+          limit: ITEMS_PER_PAGE,
+        },
+      }));
+      fetchShelters();
+    },
+    [setFilters, fetchShelters],
+  );
+
+  // Initialize pagination on mount
+  useEffect(() => {
+    setFilters((prev: GetSheltersParams) => ({
+      ...prev,
+      pagination: {
+        page: 1,
+        limit: ITEMS_PER_PAGE,
+      },
+    }));
+    fetchShelters();
+  }, [setFilters, fetchShelters]);
 
   return (
     <div className="container mx-auto max-w-6xl px-4 pb-8">
@@ -158,15 +211,37 @@ export default function ShelterList() {
           </div>
         </div>
 
-        <div className="flex items-center justify-end">
-          <span className="text-sm text-gray-500">{shelters.length} total</span>
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-gray-500">
+            Showing {(currentPage - 1) * ITEMS_PER_PAGE + 1} to{' '}
+            {Math.min(currentPage * ITEMS_PER_PAGE, totalShelters)} of{' '}
+            {totalShelters} shelters
+          </div>
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1 || loading}
+              className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none disabled:opacity-50"
+            >
+              <FontAwesomeIcon icon={faChevronLeft} className="mr-2 h-4 w-4" />
+              Previous
+            </button>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage >= totalPages || loading}
+              className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none disabled:opacity-50"
+            >
+              Next
+              <FontAwesomeIcon icon={faChevronRight} className="ml-2 h-4 w-4" />
+            </button>
+          </div>
         </div>
       </div>
 
       {shelters.length > 0 ? (
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {shelters.map((shelter) => (
-            <ShelterQuickInfo key={shelter.id} shelter={shelter} />
+            <ShelterQuickInfo key={Math.random()} shelter={shelter} />
           ))}
         </div>
       ) : (

--- a/components/map/ShelterMarker.tsx
+++ b/components/map/ShelterMarker.tsx
@@ -17,8 +17,8 @@ const ShelterMarker: FC<ShelterMarkerProps> = memo(function ShelterMarker({
 
   return (
     <Marker
-      longitude={shelter.location.longitude}
-      latitude={shelter.location.latitude}
+      longitude={shelter.location.coordinates[0]}
+      latitude={shelter.location.coordinates[1]}
       anchor="bottom"
     >
       <div onClick={() => onClick(shelter.id)} className="cursor-pointer">

--- a/components/map/ShelterPopup.tsx
+++ b/components/map/ShelterPopup.tsx
@@ -24,8 +24,8 @@ const ShelterPopup: FC<ShelterPopupProps> = memo(function ShelterPopup({
 
   return (
     <Popup
-      longitude={shelter.location.longitude}
-      latitude={shelter.location.latitude}
+      longitude={shelter.location.coordinates[0]}
+      latitude={shelter.location.coordinates[1]}
       closeButton={false}
       closeOnClick={false}
       anchor="bottom"

--- a/data/shelters.json
+++ b/data/shelters.json
@@ -4,8 +4,8 @@
       "id": "65f0f8b47d654321b9876543",
       "name": "Downtown LA Emergency Shelter",
       "location": {
-        "latitude": 34.0407,
-        "longitude": -118.2468
+        "type": "Point",
+        "coordinates": [-118.2468, 34.0407]
       },
       "address": {
         "street": "123 Main Street",
@@ -43,8 +43,8 @@
       "id": "65f0f8b47d654321b9876544",
       "name": "Hollywood Community Center",
       "location": {
-        "latitude": 34.0928,
-        "longitude": -118.3287
+        "type": "Point",
+        "coordinates": [-118.3287, 34.0928]
       },
       "address": {
         "street": "456 Hollywood Blvd",
@@ -82,8 +82,8 @@
       "id": "65f0f8b47d654321b9876545",
       "name": "Koreatown Relief Center",
       "location": {
-        "latitude": 34.061,
-        "longitude": -118.3012
+        "type": "Point",
+        "coordinates": [-118.3012, 34.061]
       },
       "address": {
         "street": "789 Western Ave",
@@ -121,8 +121,8 @@
       "id": "65f0f8b47d654321b9876546",
       "name": "East LA Family Shelter",
       "location": {
-        "latitude": 34.0224,
-        "longitude": -118.1677
+        "type": "Point",
+        "coordinates": [-118.1677, 34.0224]
       },
       "address": {
         "street": "321 Cesar E Chavez Ave",
@@ -160,8 +160,8 @@
       "id": "65f0f8b47d654321b9876547",
       "name": "Chinatown Community Center",
       "location": {
-        "latitude": 34.0623,
-        "longitude": -118.2383
+        "type": "Point",
+        "coordinates": [-118.2383, 34.0623]
       },
       "address": {
         "street": "567 N Broadway",
@@ -199,8 +199,8 @@
       "id": "65f0f8b47d654321b9876548",
       "name": "South LA Resource Center",
       "location": {
-        "latitude": 33.989,
-        "longitude": -118.2987
+        "type": "Point",
+        "coordinates": [-118.2987, 33.989]
       },
       "address": {
         "street": "890 W Vernon Ave",
@@ -238,8 +238,8 @@
       "id": "65f0f8b47d654321b9876549",
       "name": "Valley Emergency Center",
       "location": {
-        "latitude": 34.1687,
-        "longitude": -118.3782
+        "type": "Point",
+        "coordinates": [-118.3782, 34.1687]
       },
       "address": {
         "street": "123 Van Nuys Blvd",
@@ -277,8 +277,8 @@
       "id": "65f0f8b47d654321b987654a",
       "name": "Little Tokyo Support Center",
       "location": {
-        "latitude": 34.0505,
-        "longitude": -118.24
+        "type": "Point",
+        "coordinates": [-118.24, 34.0505]
       },
       "address": {
         "street": "456 E 1st St",
@@ -316,8 +316,8 @@
       "id": "65f0f8b47d654321b987654b",
       "name": "Westside Relief Station",
       "location": {
-        "latitude": 34.0211,
-        "longitude": -118.4814
+        "type": "Point",
+        "coordinates": [-118.4814, 34.0211]
       },
       "address": {
         "street": "789 Santa Monica Blvd",
@@ -355,8 +355,8 @@
       "id": "65f0f8b47d654321b987654c",
       "name": "Echo Park Crisis Center",
       "location": {
-        "latitude": 34.0781,
-        "longitude": -118.2606
+        "type": "Point",
+        "coordinates": [-118.2606, 34.0781]
       },
       "address": {
         "street": "321 Sunset Blvd",

--- a/data/shelters.json
+++ b/data/shelters.json
@@ -389,6 +389,377 @@
       "requiredLanguages": ["ENGLISH", "SPANISH", "TAGALOG"],
       "createdAt": "2024-03-12T08:09:00.000Z",
       "updatedAt": "2024-03-12T08:09:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b987654d",
+      "name": "SF Mission District Haven",
+      "location": {
+        "type": "Point",
+        "coordinates": [-122.4194, 37.7601]
+      },
+      "address": {
+        "street": "2000 Mission Street",
+        "city": "San Francisco",
+        "state": "CA",
+        "zipCode": "94110",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/sfmission.jpg",
+      "volunteerCapacity": 45,
+      "evacueeCapacity": 180,
+      "accommodations": ["Beds", "Community Kitchen", "Tech Center"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Cultural Sensitivity", "Tech Support"]
+      },
+      "suppliesNeeded": [
+        { "item": "Blankets", "received": 15, "needed": 30 },
+        { "item": "Laptops", "received": 5, "needed": 20 },
+        { "item": "Water bottles", "received": 50, "needed": 100 },
+        { "item": "Towels", "received": 25, "needed": 40 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "MANDARIN"],
+      "createdAt": "2024-03-12T08:10:00.000Z",
+      "updatedAt": "2024-03-12T08:10:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b987654e",
+      "name": "Oakland Community Shelter",
+      "location": {
+        "type": "Point",
+        "coordinates": [-122.2712, 37.8044]
+      },
+      "address": {
+        "street": "1200 Broadway",
+        "city": "Oakland",
+        "state": "CA",
+        "zipCode": "94612",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/oakland.jpg",
+      "volunteerCapacity": 40,
+      "evacueeCapacity": 160,
+      "accommodations": ["Beds", "Art Space", "Job Training Center"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Job Training", "Mental Health First Aid"]
+      },
+      "suppliesNeeded": [
+        { "item": "Art Supplies", "received": 10, "needed": 30 },
+        { "item": "Professional Clothing", "received": 20, "needed": 50 },
+        { "item": "Laptops", "received": 5, "needed": 15 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "VIETNAMESE"],
+      "createdAt": "2024-03-12T08:11:00.000Z",
+      "updatedAt": "2024-03-12T08:11:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b987654f",
+      "name": "Berkeley Youth Center",
+      "location": {
+        "type": "Point",
+        "coordinates": [-122.2728, 37.8716]
+      },
+      "address": {
+        "street": "2400 Bancroft Way",
+        "city": "Berkeley",
+        "state": "CA",
+        "zipCode": "94704",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/berkeley.jpg",
+      "volunteerCapacity": 35,
+      "evacueeCapacity": 120,
+      "accommodations": ["Beds", "Study Areas", "Computer Lab"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": false,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 21,
+        "requiredTraining": ["Youth Counseling", "Education"]
+      },
+      "suppliesNeeded": [
+        { "item": "School Supplies", "received": 30, "needed": 100 },
+        { "item": "Backpacks", "received": 15, "needed": 50 },
+        { "item": "Hygiene Kits", "received": 25, "needed": 75 }
+      ],
+      "requiredLanguages": ["ENGLISH", "MANDARIN", "KOREAN"],
+      "createdAt": "2024-03-12T08:12:00.000Z",
+      "updatedAt": "2024-03-12T08:12:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876550",
+      "name": "Denver Downtown Refuge",
+      "location": {
+        "type": "Point",
+        "coordinates": [-104.9903, 39.7392]
+      },
+      "address": {
+        "street": "1500 Lawrence Street",
+        "city": "Denver",
+        "state": "CO",
+        "zipCode": "80202",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/denver.jpg",
+      "volunteerCapacity": 50,
+      "evacueeCapacity": 200,
+      "accommodations": ["Beds", "Mountain View Lounge", "Fitness Center"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Winter Safety", "First Aid"]
+      },
+      "suppliesNeeded": [
+        { "item": "Winter Coats", "received": 30, "needed": 100 },
+        { "item": "Snow Boots", "received": 20, "needed": 80 },
+        { "item": "Thermal Blankets", "received": 40, "needed": 120 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH"],
+      "createdAt": "2024-03-12T08:13:00.000Z",
+      "updatedAt": "2024-03-12T08:13:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876551",
+      "name": "Boulder Mountain Haven",
+      "location": {
+        "type": "Point",
+        "coordinates": [-105.2705, 40.015]
+      },
+      "address": {
+        "street": "1777 Broadway",
+        "city": "Boulder",
+        "state": "CO",
+        "zipCode": "80302",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/boulder.jpg",
+      "volunteerCapacity": 30,
+      "evacueeCapacity": 120,
+      "accommodations": ["Beds", "Climbing Wall", "Meditation Room"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": true,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Outdoor Safety", "Mental Health Support"]
+      },
+      "suppliesNeeded": [
+        { "item": "Hiking Gear", "received": 10, "needed": 40 },
+        { "item": "Camping Equipment", "received": 5, "needed": 25 },
+        { "item": "First Aid Kits", "received": 15, "needed": 35 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "OTHER"],
+      "createdAt": "2024-03-12T08:14:00.000Z",
+      "updatedAt": "2024-03-12T08:14:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876552",
+      "name": "Colorado Springs Sanctuary",
+      "location": {
+        "type": "Point",
+        "coordinates": [-104.8214, 38.8339]
+      },
+      "address": {
+        "street": "215 East Pikes Peak Ave",
+        "city": "Colorado Springs",
+        "state": "CO",
+        "zipCode": "80903",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/coloradosprings.jpg",
+      "volunteerCapacity": 40,
+      "evacueeCapacity": 150,
+      "accommodations": ["Beds", "Veterans' Services", "Training Center"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 21,
+        "requiredTraining": ["Veterans Affairs", "Emergency Response"]
+      },
+      "suppliesNeeded": [
+        { "item": "Military Gear", "received": 20, "needed": 60 },
+        { "item": "Medical Supplies", "received": 30, "needed": 80 },
+        { "item": "Winter Clothing", "received": 40, "needed": 100 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "ARABIC"],
+      "createdAt": "2024-03-12T08:15:00.000Z",
+      "updatedAt": "2024-03-12T08:15:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876553",
+      "name": "Manhattan Emergency Center",
+      "location": {
+        "type": "Point",
+        "coordinates": [-73.9857, 40.7484]
+      },
+      "address": {
+        "street": "350 5th Avenue",
+        "city": "New York",
+        "state": "NY",
+        "zipCode": "10118",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/nyc.jpg",
+      "volunteerCapacity": 60,
+      "evacueeCapacity": 250,
+      "accommodations": ["Beds", "Business Center", "Urban Garden"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Urban Navigation", "Crisis Management"]
+      },
+      "suppliesNeeded": [
+        { "item": "Business Attire", "received": 50, "needed": 150 },
+        { "item": "Metro Cards", "received": 100, "needed": 300 },
+        { "item": "Phone Chargers", "received": 30, "needed": 100 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "MANDARIN", "OTHER"],
+      "createdAt": "2024-03-12T08:16:00.000Z",
+      "updatedAt": "2024-03-12T08:16:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876554",
+      "name": "Boston Harbor Shelter",
+      "location": {
+        "type": "Point",
+        "coordinates": [-71.0589, 42.3601]
+      },
+      "address": {
+        "street": "126 State Street",
+        "city": "Boston",
+        "state": "MA",
+        "zipCode": "02109",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/boston.jpg",
+      "volunteerCapacity": 45,
+      "evacueeCapacity": 175,
+      "accommodations": ["Beds", "Study Hall", "Maritime View"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Maritime Safety", "Education Support"]
+      },
+      "suppliesNeeded": [
+        { "item": "Rain Gear", "received": 25, "needed": 75 },
+        { "item": "Study Materials", "received": 40, "needed": 100 },
+        { "item": "Winter Clothing", "received": 60, "needed": 150 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "FRENCH"],
+      "createdAt": "2024-03-12T08:17:00.000Z",
+      "updatedAt": "2024-03-12T08:17:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876555",
+      "name": "DC Capitol Support Center",
+      "location": {
+        "type": "Point",
+        "coordinates": [-77.0369, 38.9072]
+      },
+      "address": {
+        "street": "1275 K Street NW",
+        "city": "Washington",
+        "state": "DC",
+        "zipCode": "20005",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/dc.jpg",
+      "volunteerCapacity": 50,
+      "evacueeCapacity": 200,
+      "accommodations": ["Beds", "Policy Center", "Conference Rooms"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Policy Education", "Government Services"]
+      },
+      "suppliesNeeded": [
+        { "item": "Professional Attire", "received": 45, "needed": 120 },
+        { "item": "Laptops", "received": 15, "needed": 50 },
+        { "item": "Metro Passes", "received": 80, "needed": 200 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "FRENCH", "ARABIC"],
+      "createdAt": "2024-03-12T08:18:00.000Z",
+      "updatedAt": "2024-03-12T08:18:00.000Z"
+    },
+    {
+      "id": "65f0f8b47d654321b9876556",
+      "name": "Miami Beach Relief Center",
+      "location": {
+        "type": "Point",
+        "coordinates": [-80.13, 25.7907]
+      },
+      "address": {
+        "street": "1701 Collins Avenue",
+        "city": "Miami Beach",
+        "state": "FL",
+        "zipCode": "33139",
+        "country": "USA"
+      },
+      "picture": "https://example.com/shelters/miami.jpg",
+      "volunteerCapacity": 55,
+      "evacueeCapacity": 220,
+      "accommodations": ["Beds", "Beach Access", "Hurricane Shelter"],
+      "wheelchairAccessible": true,
+      "housesLargeAnimals": false,
+      "housesSmallAnimals": true,
+      "hasCounselingUnit": true,
+      "foodProvided": true,
+      "waterProvided": true,
+      "volunteerPreferences": {
+        "minAge": 18,
+        "requiredTraining": ["Hurricane Preparedness", "Water Safety"]
+      },
+      "suppliesNeeded": [
+        { "item": "Hurricane Supplies", "received": 50, "needed": 150 },
+        { "item": "Beach Safety Gear", "received": 30, "needed": 80 },
+        { "item": "Sunscreen", "received": 100, "needed": 300 }
+      ],
+      "requiredLanguages": ["ENGLISH", "SPANISH", "FRENCH", "OTHER"],
+      "createdAt": "2024-03-12T08:19:00.000Z",
+      "updatedAt": "2024-03-12T08:19:00.000Z"
     }
   ]
 }

--- a/lib/actions/shelter.schema.ts
+++ b/lib/actions/shelter.schema.ts
@@ -1,28 +1,39 @@
 import { z } from 'zod';
-import type { Prisma } from '@prisma/client';
 import {
   EnumLanguageNullableListFilterSchema,
   BoolFilterSchema,
   SupplyObjectEqualityInputSchema,
-  CoordinateObjectEqualityInputSchema,
-  CoordinateNullableCompositeFilterSchema,
   StringFilterSchema,
   IntNullableFilterSchema,
   StringNullableListFilterSchema,
-  JsonNullableFilterSchema,
   SupplyCompositeListFilterSchema,
+  VolunteerPreferencesObjectEqualityInputSchema,
+  VolunteerPreferencesNullableCompositeFilterSchema,
 } from '@/prisma/generated/zod';
 
-export const GetSheltersParamsSchema: z.ZodType<Prisma.ShelterWhereInput> = z
+export interface Coordinates {
+  longitude: number;
+  latitude: number;
+}
+
+export interface PaginationParams {
+  page: number;
+  limit: number;
+}
+
+export const CoordinatesSchema = z.object({
+  longitude: z.number(),
+  latitude: z.number(),
+});
+
+export const PaginationParamsSchema = z.object({
+  page: z.number().int().positive(),
+  limit: z.number().int().positive().max(100),
+});
+
+export const GetSheltersParamsSchema = z
   .object({
     name: z.union([z.lazy(() => StringFilterSchema), z.string()]).optional(),
-    location: z
-      .union([
-        z.lazy(() => CoordinateNullableCompositeFilterSchema),
-        z.lazy(() => CoordinateObjectEqualityInputSchema),
-      ])
-      .optional()
-      .nullable(),
     volunteerCapacity: z
       .union([z.lazy(() => IntNullableFilterSchema), z.number()])
       .optional()
@@ -50,7 +61,13 @@ export const GetSheltersParamsSchema: z.ZodType<Prisma.ShelterWhereInput> = z
     waterProvided: z
       .union([z.lazy(() => BoolFilterSchema), z.boolean()])
       .optional(),
-    volunteerPreferences: z.lazy(() => JsonNullableFilterSchema).optional(),
+    volunteerPreferences: z
+      .union([
+        z.lazy(() => VolunteerPreferencesNullableCompositeFilterSchema),
+        z.lazy(() => VolunteerPreferencesObjectEqualityInputSchema),
+      ])
+      .optional()
+      .nullable(),
     suppliesNeeded: z
       .union([
         z.lazy(() => SupplyCompositeListFilterSchema),
@@ -60,6 +77,8 @@ export const GetSheltersParamsSchema: z.ZodType<Prisma.ShelterWhereInput> = z
     requiredLanguages: z
       .lazy(() => EnumLanguageNullableListFilterSchema)
       .optional(),
+    coordinates: CoordinatesSchema.optional(),
+    pagination: PaginationParamsSchema.optional(),
   })
   .strict();
 

--- a/lib/actions/shelter.ts
+++ b/lib/actions/shelter.ts
@@ -3,27 +3,132 @@ import { prisma } from '@/lib/prisma';
 import type { Prisma, Shelter } from '@prisma/client';
 import type { ActionResult } from '@/types/models';
 import { unstable_cache } from 'next/cache';
-import { GetSheltersParams } from './shelter.schema';
+import type {
+  GetSheltersParams,
+  Coordinates,
+  PaginationParams,
+} from './shelter.schema';
+
+interface GeoNearResult {
+  cursor: {
+    firstBatch: Array<Shelter & { distance: number }>;
+  };
+  ok: number;
+}
+
+interface GeoNearStage {
+  $geoNear: {
+    near: {
+      type: 'Point';
+      coordinates: [number, number];
+    };
+    distanceField: string;
+    spherical: boolean;
+    query: Prisma.ShelterWhereInput;
+  };
+}
+
+interface SkipStage {
+  $skip: number;
+}
+
+interface LimitStage {
+  $limit: number;
+}
+
+type AggregationStage = GeoNearStage | SkipStage | LimitStage;
 
 /**
- * Action that fetches all shelters from the database
+ * Action that fetches all shelters from the database with optional geospatial sorting and pagination
  */
 export const getShelters = unstable_cache(
   async (params: GetSheltersParams = {}): Promise<ActionResult<Shelter[]>> => {
     try {
+      const { coordinates, pagination, ...whereParams } = params as {
+        coordinates?: Coordinates;
+        pagination?: PaginationParams;
+        [key: string]: unknown;
+      };
+
+      if (isValidCoordinates(coordinates)) {
+        // Use MongoDB's $geoNear for geospatial queries
+        const pipeline: AggregationStage[] = [
+          {
+            $geoNear: {
+              near: {
+                type: 'Point',
+                coordinates: [coordinates.longitude, coordinates.latitude],
+              },
+              distanceField: 'distance',
+              spherical: true,
+              query: whereParams,
+            },
+          },
+        ];
+
+        if (isValidPagination(pagination)) {
+          const skip = (pagination.page - 1) * pagination.limit;
+          pipeline.push({ $skip: skip }, { $limit: pagination.limit });
+        }
+
+        const shelters = (await prisma.$runCommandRaw({
+          aggregate: 'Shelter',
+          pipeline: pipeline as unknown as Prisma.InputJsonValue[],
+          cursor: {},
+        })) as unknown as GeoNearResult;
+
+        if (!shelters?.cursor?.firstBatch) {
+          return { success: true, data: [] };
+        }
+
+        return {
+          success: true,
+          data: shelters.cursor.firstBatch,
+        };
+      }
+
+      // If no coordinates provided, use regular findMany with pagination
+      const paginationOptions = isValidPagination(pagination)
+        ? {
+            skip: (pagination.page - 1) * pagination.limit,
+            take: pagination.limit,
+          }
+        : undefined;
+
       const shelters = await prisma.shelter.findMany({
-        where: params,
+        where: whereParams as Prisma.ShelterWhereInput,
+        ...paginationOptions,
       });
+
       return { success: true, data: shelters };
     } catch (e) {
-      console.log(e);
-
+      console.error('[ShelterList] Error:', e);
       throw new Error('[ShelterList] Failed to fetch shelters from database');
     }
   },
   ['shelters'],
   { revalidate: 3600, tags: ['shelters'] },
 );
+
+function isValidCoordinates(
+  coords: Coordinates | undefined,
+): coords is Coordinates {
+  return (
+    coords !== undefined &&
+    typeof coords.longitude === 'number' &&
+    typeof coords.latitude === 'number'
+  );
+}
+
+function isValidPagination(
+  pagination: PaginationParams | undefined,
+): pagination is PaginationParams {
+  return (
+    pagination !== undefined &&
+    typeof pagination.page === 'number' &&
+    typeof pagination.limit === 'number'
+  );
+}
 
 /**
  * Action that fetches a single shelter from the database

--- a/lib/hooks/useShelters.ts
+++ b/lib/hooks/useShelters.ts
@@ -14,6 +14,7 @@ import type { GetSheltersParams } from '@/lib/actions/shelter.schema';
 /** Hook for fetching shelters */
 export function useShelters(params: GetSheltersParams = {}) {
   const [shelters, setShelters] = useState<Shelter[]>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,7 +23,8 @@ export function useShelters(params: GetSheltersParams = {}) {
     try {
       const result = await getShelters(params);
       if (result.success) {
-        setShelters(result.data);
+        setShelters(result.data.shelters);
+        setTotalCount(result.data.total);
       } else {
         setError('Failed to fetch shelters');
       }
@@ -38,7 +40,7 @@ export function useShelters(params: GetSheltersParams = {}) {
     fetchShelters();
   });
 
-  return { shelters, loading, error, refetch: fetchShelters };
+  return { shelters, totalCount, loading, error, refetch: fetchShelters };
 }
 
 /** Hook for deleting specific shelter */

--- a/lib/store/shelterStore.ts
+++ b/lib/store/shelterStore.ts
@@ -8,12 +8,15 @@ interface ShelterState {
   loading: boolean;
   error: string | null;
   filters: GetSheltersParams;
+  totalShelters: number;
+  currentPage: number;
   setFilters: (
     setFunc: (prevFilters: GetSheltersParams) => GetSheltersParams,
   ) => void;
   setShelters: (shelters: Shelter[]) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
+  setCurrentPage: (page: number) => void;
   fetchShelters: () => Promise<void>;
   refetch: () => Promise<void>;
 }
@@ -26,7 +29,11 @@ export const useShelterStore = create<ShelterState>()((set, get) => {
     try {
       const result = await getShelters(filters);
       if (result.success) {
-        set({ shelters: result.data });
+        set({
+          shelters: result.data.shelters,
+          totalShelters: result.data.total,
+          currentPage: filters.pagination?.page || 1,
+        });
       } else {
         set({ error: 'Failed to fetch shelters' });
       }
@@ -43,6 +50,8 @@ export const useShelterStore = create<ShelterState>()((set, get) => {
     loading: false,
     error: null,
     filters: {},
+    totalShelters: 0,
+    currentPage: 1,
 
     setFilters: (setFunc) =>
       set((state) => ({
@@ -52,6 +61,7 @@ export const useShelterStore = create<ShelterState>()((set, get) => {
     setShelters: (shelters) => set({ shelters }),
     setLoading: (loading) => set({ loading }),
     setError: (error) => set({ error }),
+    setCurrentPage: (page) => set({ currentPage: page }),
 
     fetchShelters,
     refetch: fetchShelters,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,9 +45,9 @@ type Address {
   country String
 }
 
-type Coordinate {
-  latitude  Float
-  longitude Float
+type Location {
+  type        String    @default("Point")
+  coordinates Float[]
 }
 
 type TimeSlot {
@@ -59,6 +59,11 @@ type Supply {
   item      String
   received  Int
   needed    Int
+}
+
+type VolunteerPreferences {
+  minAge           Int
+  requiredTraining String[]
 }
 
 model Volunteer {
@@ -78,7 +83,7 @@ model Volunteer {
 model Shelter {
   id                  String            @id @default(auto()) @map("_id") @db.ObjectId
   name                String
-  location            Coordinate?
+  location            Location?
   address             Address
   picture             String?
   volunteerCapacity   Int?
@@ -90,7 +95,7 @@ model Shelter {
   hasCounselingUnit   Boolean          @default(false)
   foodProvided        Boolean          @default(false)
   waterProvided       Boolean          @default(false)
-  volunteerPreferences Json?
+  volunteerPreferences VolunteerPreferences?
   suppliesNeeded      Supply[]         
   requiredLanguages   Language[]       
   signups             VolunteerSignup[]

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -9,35 +9,35 @@ const prisma = new PrismaClient();
 
 async function main() {
   try {
-    console.log('Clearing existing data...');
-    await prisma.volunteerSignup.deleteMany();
-    await prisma.volunteer.deleteMany();
-    await prisma.shelter.deleteMany();
+    console.log('Starting database seeding...');
 
-    console.log('Creating volunteers...');
-    for (const volunteer of volunteerData) {
-      await prisma.volunteer.create({
-        data: volunteer,
+    await prisma.$transaction(async (tx) => {
+      console.log('Clearing existing data...');
+      await tx.volunteerSignup.deleteMany();
+      await tx.volunteer.deleteMany();
+      await tx.shelter.deleteMany();
+
+      console.log('Creating volunteers...');
+      await tx.volunteer.createMany({
+        data: volunteerData,
       });
-    }
 
-    console.log('Creating shelters...');
-    for (const shelter of shelterData) {
-      await prisma.shelter.create({
-        data: shelter,
+      console.log('Creating shelters...');
+      await tx.shelter.createMany({
+        data: shelterData,
       });
-    }
 
-    console.log('Creating volunteer signups...');
-    for (const signup of signupData) {
-      await prisma.volunteerSignup.create({
-        data: signup,
-      });
-    }
+      console.log('Creating volunteer signups...');
+      for (const signup of signupData) {
+        await tx.volunteerSignup.create({
+          data: signup,
+        });
+      }
+    });
 
-    console.log('Seeding completed successfully!');
+    console.log('Database seeding completed successfully!');
   } catch (error) {
-    console.error('Error seeding the database:', error);
+    console.error('Error seeding database:', error);
     throw error;
   } finally {
     await prisma.$disconnect();


### PR DESCRIPTION
This PR changes shelter fetching logic so it orders by distance from user's location.

(not shown here) add a 2dsphere index on the 'location' key for shelters in mongodb.

Now, the shelter list in the bottom sheet is paginated, and is ordered based on distance from user:


https://github.com/user-attachments/assets/e9e11d09-1325-4660-afdd-0b6de06929fe

